### PR TITLE
5 repeat attack too sensitive

### DIFF
--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -123,12 +123,7 @@ namespace OCPA
 			isAttacking = false;
 		}
 
-		// if (currentAnimState == RE::ATTACK_STATE_ENUM::kSwing || currentAnimState == RE::ATTACK_STATE_ENUM::kHit) {
-		// 	hitWindow = true;
-		// } else {
-		// 	hitWindow = false;
-		// }
-
+		// Capture HitFrame events to flag when repeated attacks are listened for.
 		if (a_event->tag == "HitFrame") {
 			hitWindow = true;
 		} else {

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -79,8 +79,17 @@ namespace OCPA
 		bool isBlocking = false;
 		a_actor->GetGraphVariableBool("IsBlocking", isBlocking);
 
+		std::string race = player->GetRace()->fullName.c_str();
+
+		// Prevent power attack spam.
+		if (race == "Vampire Lord" || race == "Werewolf") {
+			RE::ATTACK_STATE_ENUM currentAnimState = (a_actor->AsActorState()->actorState1.meleeAttackState);
+			if (currentAnimState != RE::ATTACK_STATE_ENUM::kNone) {
+				return;
+			}
+		}
+
 		if (isJumping || isBlocking) {
-			logger::info("IsBlocking in PowerAttack");
 			PerformAction(actionRightAttack, a_actor);
 			std::thread thread(&Main::AltPowerAttack, Main::GetSingleton(), a_actor);
 			thread.detach();
@@ -112,6 +121,18 @@ namespace OCPA
 			isAttacking = true;
 		} else {
 			isAttacking = false;
+		}
+
+		// if (currentAnimState == RE::ATTACK_STATE_ENUM::kSwing || currentAnimState == RE::ATTACK_STATE_ENUM::kHit) {
+		// 	hitWindow = true;
+		// } else {
+		// 	hitWindow = false;
+		// }
+
+		if (a_event->tag == "HitFrame") {
+			hitWindow = true;
+		} else {
+			hitWindow = false;
 		}
 
 		// MCO Specific implementation to flag attack window for succession.
@@ -182,6 +203,12 @@ namespace OCPA
 
 		// Check keycode against current bindings.
 		if (!normalAttack && !powerAttack) {
+			return false;
+		}
+
+		std::string race = player->GetRace()->fullName.c_str();
+
+		if (race == "Vampire Lord" || race == "Werewolf") {
 			return false;
 		}
 
@@ -287,6 +314,9 @@ namespace OCPA
 			player->NotifyAnimationGraph("attackRelease");
 		}
 
+		bool inHitFrame = false;
+		player->GetGraphVariableBool("HitFrame", inHitFrame);
+
 		if (Utility::IsNormalAttack(a_event)) {
 			switch (config->longPressMode) {
 			case Settings::LongPressMode::kVanilla:  // 0
@@ -300,17 +330,14 @@ namespace OCPA
 				if (a_event->heldDownSecs >= fInitialPowerAttackDelay->GetFloat()) {
 					return false;
 				}
-
-				if (a_event->IsDown()) {
-					Attack(player);
-				}
 				break;
 			case Settings::LongPressMode::kRepeat:  // 2
-				if (a_event->IsDown() && !isAttacking) {
+				if (a_event->IsHeld() && hitWindow) {
 					Attack(player);
-				} else if (a_event->IsHeld() && isAttacking) {
+				} else if (a_event->IsDown()) {
 					Attack(player);
 				}
+				return false;
 				break;
 			default:  // kDisable
 				if (a_event->IsDown()) {
@@ -343,17 +370,6 @@ namespace OCPA
 
 				bool wantPowerAttack = false;
 				bool wantDualPowerAttack = false;
-
-				// bool isBlockKey = config->blockKey[b_event->device.get()] == keyCode;
-
-				// if (auto ply = RE::PlayerCharacter::GetSingleton()) {
-				// 	if (isBlockKey && b_event->IsUp()) {
-				// 		ply->NotifyAnimationGraph("MCO_EndAnimation");
-				// 		ply->NotifyAnimationGraph("blockStop");
-				// 		logger::info("blockStop");
-				// 		return;
-				// 	}
-				// }
 
 				if (keyCode == (uint32_t)config->modifierKey && b_event->IsDown()) {
 					keyComboPressed = true;

--- a/src/Main.h
+++ b/src/Main.h
@@ -44,6 +44,7 @@ namespace OCPA
 
 		// State & Timers
 		bool attackWindow = false;
+		bool hitWindow = false;
 		bool isAttacking = false;
 		float paQueueTime = 0.f;
 		float queuePAExpire = 0.2f;  // ?

--- a/src/Utility.h
+++ b/src/Utility.h
@@ -58,18 +58,13 @@ namespace OCPA
 			uint32_t keyCode = GetKeycode(a_event);
 
 			if (keyCode == (uint32_t)config->paKey) {
-				logger::info("Test");
 				if (config->modifierKey >= 2) {
 					if (config->onlyFirstAttack) {
-						logger::info("onlyFirstAttack");
 						if (isAttacking) {
-							logger::info("1");
 							return true;  // Power attack without modifier
 						} else if (keyComboPressed) {
-							logger::info("2");
 							return true;  // Not attacking, require modifier
 						} else {
-							logger::info("3");
 							return false;  // Above conditions not met, abort.
 						}
 					}
@@ -94,11 +89,9 @@ namespace OCPA
 			uint32_t attackKey = config->attackKey[a_event->device.get()];
 
 			if (keyCode == attackKey) {
-				logger::info("IsNormalAttack = True");
 				return true;
 			}
 
-			logger::info("IsNormalAttack = false");
 			return false;
 		};
 


### PR DESCRIPTION
* Fixed issue with repeat attack mode sometimes firing a normal attack unexpectedly due to timing. Now relies on Skyrim HitFrame event to fire during key press to register as a consecutive attack.
* Fixed reported issues with Werewolf form being broken while using OCPA. Related to OCPA logic not fitting well with Werewolf form behaviors. Disabled input/output from `AttackBlockHandler` while in werewolf form. Added some checks for power attack keybind.